### PR TITLE
Changed permissions for responses and surveys

### DIFF
--- a/app/controllers/responses.js
+++ b/app/controllers/responses.js
@@ -70,8 +70,8 @@ module.exports = controller({
   update,
   destroy
 }, { before: [
-  { method: setUser, only: ['index', 'show'] },
-  { method: authenticate, except: ['index', 'show'] },
-  { method: setModel(Response), only: ['show'] },
-  { method: setModel(Response, { forUser: true }), only: ['update', 'destroy'] }
+  // { method: setUser, only: ['index', 'show'] },
+  { method: authenticate },
+  // { method: setModel(Response), only: ['show'] },
+  { method: setModel(Response, { forUser: true }), only: ['index', 'show', 'update', 'destroy'] }
 ] })

--- a/app/controllers/surveys.js
+++ b/app/controllers/surveys.js
@@ -64,8 +64,8 @@ module.exports = controller({
   update,
   destroy
 }, { before: [
-  { method: setUser, only: ['index', 'show'] },
-  { method: authenticate, except: ['index', 'show'] },
-  { method: setModel(Survey), only: ['show'] },
+  // { method: setUser, only: ['index', 'show'] },
+  { method: authenticate },
+  { method: setModel(Survey), only: ['index', 'show'] },
   { method: setModel(Survey, { forUser: true }), only: ['update', 'destroy'] }
 ] })


### PR DESCRIPTION
Got rid of method: setUser because we want everything regarding
this app to only be available to people who are signed in

We got rid of except clauses on method:authenticate because we want
authentication for everything

We got rid of method: setModel for responses since we don't want
people to be able to see responses (people will be able to see response
data by checking out survey.responses)

we made setModel forUser: true for all response actions

Jesse Louis