### PR TITLE
Reversed our restrictions on authentication for survey and response

### DIFF
--- a/app/controllers/responses.js
+++ b/app/controllers/responses.js
@@ -70,8 +70,8 @@ module.exports = controller({
   update,
   destroy
 }, { before: [
-  // { method: setUser, only: ['index', 'show'] },
-  { method: authenticate },
-  // { method: setModel(Response), only: ['show'] },
-  { method: setModel(Response, { forUser: true }), only: ['index', 'show', 'update', 'destroy'] }
+  { method: setUser, only: ['index', 'show'] },
+  { method: authenticate, except: ['index', 'show'] },
+  { method: setModel(Response), only: ['show'] },
+  { method: setModel(Response, { forUser: true }), only: ['update', 'destroy'] }
 ] })

--- a/app/controllers/surveys.js
+++ b/app/controllers/surveys.js
@@ -10,6 +10,7 @@ const setUser = require('./concerns/set-current-user')
 const setModel = require('./concerns/set-mongoose-model')
 
 const index = (req, res, next) => {
+  console.log('we are inside index right now')
   Survey.find()
   .then(surveys => res.json({
     surveys: surveys.map((e) =>
@@ -64,8 +65,8 @@ module.exports = controller({
   update,
   destroy
 }, { before: [
-  // { method: setUser, only: ['index', 'show'] },
-  { method: authenticate },
-  { method: setModel(Survey), only: ['index', 'show'] },
+  { method: setUser, only: ['index', 'show'] },
+  { method: authenticate, except: ['index', 'show'] },
+  { method: setModel(Survey), only: ['show'] },
   { method: setModel(Survey, { forUser: true }), only: ['update', 'destroy'] }
 ] })


### PR DESCRIPTION
It was breaking our index actions on both, returning 404 when we
expected to see models that were owned by us, and 401 when we tried
to see models that were owned by someone else

reverted them to default which is less restrictive than we wanted
but ultimately there's no sensitive data floating around, so it's
ok for now